### PR TITLE
Move CDN to `libraries` repo

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,8 +6,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="description" content="">
     <meta name="author" content="">
-	<script src="https://amsterdam.github.io/x3/v0.1/d3.min.js"></script>
-	<script src="https://amsterdam.github.io/x3/v0.1/x3.min.js"></script>
+	<script src="https://amsterdam.github.io/libraries/x3/v0.1/d3.min.js"></script>
+	<script src="https://amsterdam.github.io/libraries/x3/v0.1/x3.min.js"></script>
 	<script src="./assets/js/visualisaties/bereikh2.js"></script>
 	<script src="./assets/js/visualisaties/bereikh2_1_1.js"></script>
 	<script src="./assets/js/visualisaties/bereikh2_1_2.js"></script>


### PR DESCRIPTION
Now using the `libraries` repo to serve the libraries over GH Pages.

https://github.com/Amsterdam/libraries

https://github.com/Amsterdam/amsterdam.github.io/issues/15